### PR TITLE
[#1] Local Notification 기능 구현

### DIFF
--- a/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
+++ b/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		26C965CD2C5241F9000257EA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26C965CC2C5241F9000257EA /* Assets.xcassets */; };
 		26C965D02C5241F9000257EA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26C965CF2C5241F9000257EA /* Preview Assets.xcassets */; };
 		26C965D82C537CB8000257EA /* LocalNotificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C965D72C537CB8000257EA /* LocalNotificationType.swift */; };
+		26C965DA2C538046000257EA /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C965D92C538046000257EA /* NotificationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,7 @@
 		26C965CC2C5241F9000257EA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		26C965CF2C5241F9000257EA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		26C965D72C537CB8000257EA /* LocalNotificationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationType.swift; sourceTree = "<group>"; };
+		26C965D92C538046000257EA /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,6 +183,7 @@
 			isa = PBXGroup;
 			children = (
 				26C965D72C537CB8000257EA /* LocalNotificationType.swift */,
+				26C965D92C538046000257EA /* NotificationManager.swift */,
 			);
 			path = Notification;
 			sourceTree = "<group>";
@@ -303,6 +306,7 @@
 				26C965CB2C5241F8000257EA /* ContentView.swift in Sources */,
 				1BAAB4F72C576CCF00B73AF0 /* Int+Extension.swift in Sources */,
 				26C965C92C5241F8000257EA /* MoonCrystalApp.swift in Sources */,
+				26C965DA2C538046000257EA /* NotificationManager.swift in Sources */,
 				26C965D82C537CB8000257EA /* LocalNotificationType.swift in Sources */,
 				1E87A6D62C593D5B00BD28D1 /* ProgressHalfCircleView.swift in Sources */,
 				1BAAB4FD2C57A67700B73AF0 /* CapacityCalculator.swift in Sources */,

--- a/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
+++ b/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		26C965CB2C5241F8000257EA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C965CA2C5241F8000257EA /* ContentView.swift */; };
 		26C965CD2C5241F9000257EA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26C965CC2C5241F9000257EA /* Assets.xcassets */; };
 		26C965D02C5241F9000257EA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26C965CF2C5241F9000257EA /* Preview Assets.xcassets */; };
+		26C965D82C537CB8000257EA /* LocalNotificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C965D72C537CB8000257EA /* LocalNotificationType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,7 @@
 		26C965CA2C5241F8000257EA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		26C965CC2C5241F9000257EA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		26C965CF2C5241F9000257EA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		26C965D72C537CB8000257EA /* LocalNotificationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -153,6 +155,7 @@
 			children = (
 				26C965C82C5241F8000257EA /* MoonCrystalApp.swift */,
 				26C965CA2C5241F8000257EA /* ContentView.swift */,
+				26C965D62C537C9D000257EA /* Notification */,
 				1BAAB4FC2C57A67700B73AF0 /* CapacityCalculator.swift */,
 				1BAAB4EE2C54D7E400B73AF0 /* MediaCapacityConverter.swift */,
 				1BAAB4F62C576CCF00B73AF0 /* Int+Extension.swift */,
@@ -172,6 +175,14 @@
 				26C965CF2C5241F9000257EA /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		26C965D62C537C9D000257EA /* Notification */ = {
+			isa = PBXGroup;
+			children = (
+				26C965D72C537CB8000257EA /* LocalNotificationType.swift */,
+			);
+			path = Notification;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -292,6 +303,7 @@
 				26C965CB2C5241F8000257EA /* ContentView.swift in Sources */,
 				1BAAB4F72C576CCF00B73AF0 /* Int+Extension.swift in Sources */,
 				26C965C92C5241F8000257EA /* MoonCrystalApp.swift in Sources */,
+				26C965D82C537CB8000257EA /* LocalNotificationType.swift in Sources */,
 				1E87A6D62C593D5B00BD28D1 /* ProgressHalfCircleView.swift in Sources */,
 				1BAAB4FD2C57A67700B73AF0 /* CapacityCalculator.swift in Sources */,
 				1BAAB4EF2C54D7E400B73AF0 /* MediaCapacityConverter.swift in Sources */,

--- a/MoonCrystal/MoonCrystal/Notification/LocalNotificationType.swift
+++ b/MoonCrystal/MoonCrystal/Notification/LocalNotificationType.swift
@@ -5,10 +5,54 @@
 //  Created by zaehorang on 7/26/24.
 //
 
+enum NotificationType: String {
+    case refresh
+    case result
+    
+    func content(favoritIdol: String? = nil, deletedCapacity: String? = nil, deletedTotalCapacity: String? = nil) -> (title: String, body: String) {
+        switch self {
+        case .refresh:
+            let title = "현재 얼마나 지웠는지 확인해볼까요?"
+            let body = "잠금화면에서 새로고침을 누르면 실시간 현황을 확인할 수 있어요"
+            return (title, body)
+            
+        case .result:
+            guard let favoritIdol = favoritIdol, let data = deletedCapacity, let total = deletedTotalCapacity else {
+                return ("Result Notification", "지금까지 정리된 내용을 확인할 수 없습니다.")
+            }
+            let title = "\(data) 정리 완료!"
+            let body = "지금까지 \(favoritIdol)를 위해 \(total)를 정리했어요"
+            return (title, body)
+        }
+    }
+}
+
 struct LocalNotification {
-    var identifier: String
+    var type: NotificationType
+    var identifier: String {
+        type.rawValue
+    }
     var title: String
     var body: String
     var timeInterval: Double
     var repeats: Bool
+    
+    /// LocalNotification 초기화 메서드
+    /// - Parameters:
+    ///   - type: Notification의 타입을 나타냅니다 (`refresh`, `result`).
+    ///   - favoritIdol: `result` 타입일 때 사용되며, 사용자의 좋아하는 아이돌을 나타냅니다.
+    ///   - deletedCapacity: `result` 타입일 때 사용되며, 정리된 데이터의 종류를 나타냅니다.
+    ///   - deletedTotalCapacity: `result` 타입일 때 사용되며, 정리된 데이터의 총량을 나타냅니다.
+    ///   - timeInterval: Notification이 트리거되는 시간을 설정합니다.
+    ///   - repeats: Notification이 반복되는지 여부를 설정합니다.
+    init(type: NotificationType, favoritIdol: String? = nil, deletedCapacity: String? = nil, deletedTotalCapacity: String? = nil, timeInterval: Double, repeats: Bool = false) {
+        self.type = type
+        self.timeInterval = timeInterval
+        self.repeats = repeats
+        
+        // NotificationType에 따라 제목과 설명을 설정합니다.
+        let content = type.content(favoritIdol: favoritIdol, deletedCapacity: deletedCapacity, deletedTotalCapacity: deletedTotalCapacity)
+        self.title = content.title
+        self.body = content.body
+    }
 }

--- a/MoonCrystal/MoonCrystal/Notification/LocalNotificationType.swift
+++ b/MoonCrystal/MoonCrystal/Notification/LocalNotificationType.swift
@@ -1,0 +1,14 @@
+//
+//  LocalNotification.swift
+//  MoonCrystal
+//
+//  Created by zaehorang on 7/26/24.
+//
+
+struct LocalNotification {
+    var identifier: String
+    var title: String
+    var body: String
+    var timeInterval: Double
+    var repeats: Bool
+}

--- a/MoonCrystal/MoonCrystal/Notification/NotificationManager.swift
+++ b/MoonCrystal/MoonCrystal/Notification/NotificationManager.swift
@@ -1,0 +1,73 @@
+//
+//  NotificationManager.swift
+//  MoonCrystal
+//
+//  Created by zaehorang on 7/26/24.
+//
+
+import Foundation
+import NotificationCenter
+
+@MainActor
+class NotificationManager: NSObject, ObservableObject {
+    private let notificationCenter = UNUserNotificationCenter.current()
+    @Published var isGranted = false
+    @Published var didTapNotification = false
+    
+    override init() {
+        super.init()
+        notificationCenter.delegate = self
+    }
+    
+    /// Notification 권한 요청 함수
+    func requestAuthorization() async throws {
+        do {
+            try await notificationCenter
+                .requestAuthorization(options: [.sound, .badge, .alert])
+        } catch {
+            print("❌ NotificationManager/requestAuthorization: \(error.localizedDescription)")
+        }
+        
+        await getCurrentSettings()
+    }
+    
+    /// 현재 Notification 권한 설정을 가져오는 함수
+    func getCurrentSettings() async {
+        let currentSettings = await notificationCenter.notificationSettings()
+        isGranted = (currentSettings.authorizationStatus == .authorized)
+    }
+
+    /// Notification 권한 거부 시, 사용자에게 앱 설정 화면을 열도록 안내하는 함수
+    func openSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            if UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url)
+            }
+        }
+    }
+    
+    /// 주어진 LocalNotification을 스케줄링하는 함수
+    /// - Parameter localNotification: 스케줄링할 로컬 알림의 정보가 담긴 LocalNotification 구조체
+    func schedule(localNotification: LocalNotification) async {
+        let content = UNMutableNotificationContent()
+        content.title = localNotification.title
+        content.body = localNotification.body
+        content.sound = .default
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: localNotification.timeInterval, repeats: localNotification.repeats)
+        let request = UNNotificationRequest(identifier: localNotification.identifier, content: content, trigger: trigger)
+        
+        do {
+            try await notificationCenter.add(request)
+        } catch {
+            print("❌ NotificationManager/schedule: \(error.localizedDescription)")
+        }
+    }
+}
+
+//MARK: - Ex_UNUserNotificationCenterDelegate
+extension NotificationManager: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
+        didTapNotification = true
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

> - Notification 상황을 두 가지 (refresh, result)로 구분하여 NotificationType enum을 추가했습니다.
> - 이 enum을 사용하여 알림의 제목과 내용을 설정할 수 있는 LocalNotification 모델을 만들었습니다.
> - 새로운 메서드를 통해 알림을 스케줄링하고, 모든 대기 중인 알림을 지울 수 있게 구현했습니다.
> - 또한, UNUserNotificationCenterDelegate 메서드를 업데이트하여 각 알림 타입에 따라 특정 변수를 수정하도록 로직을 개선했습니다.

## 💬 리뷰 요구사항(선택)

> - LocalNotification 초기화 메서드에서 타입에 따라 제목과 내용을 설정하는 방식이 적절한지 확인 부탁드립니다.
> - 두 가지 케이스로 구분된 NotificationType enum 방식이 적절한지 검토 부탁드립니다.
> - 추가로, 각 enum 케이스와 관련된 텍스트를 해당 타입의 메서드로 구현한 방식이 적절한지 확인 부탁드립니다.
