### PR TITLE
[#41] 정리할 용량이 0인 경우 정리하기 버튼 비활성화

### DIFF
--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
@@ -115,13 +115,14 @@ struct CapacitySettingView: View {
                 } label: {
                     RoundedRectangle(cornerRadius: 12)
                         .frame(height: 68)
-                        .foregroundStyle(.gray900)
+                        .foregroundStyle(selectedCapacity == 0 ? .gray400 : .gray900)
                         .overlay(
                             Text("정리 시작하기")
                                 .font(.system(size: 16))
                                 .foregroundStyle(.white)
                         )
                 }
+                .disabled(selectedCapacity == 0)
                 .padding(.horizontal, 20)
                 .padding(.top, 60)
                 


### PR DESCRIPTION
## 📝 작업 내용
- 인풋화면에 있는 정리하기 버튼이 0이 선택되었을 때 비활성화되도록 설정함

### 스크린샷 (선택)
<img width="266" alt="스크린샷 2024-08-04 오후 4 42 14" src="https://github.com/user-attachments/assets/bee0ca15-7b89-4101-9981-005cd14b4b7b">


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
