### PR TITLE
[#46] 커스텀 NumPad를 추가하고, 총용량을 변수로 홈화면부터 연결

### DIFF
--- a/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
+++ b/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1BAAB4F72C576CCF00B73AF0 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAAB4F62C576CCF00B73AF0 /* Int+Extension.swift */; };
 		1BAAB4FB2C57872600B73AF0 /* VideoFormatCapacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAAB4FA2C57872600B73AF0 /* VideoFormatCapacity.swift */; };
 		1BAAB4FD2C57A67700B73AF0 /* CapacityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAAB4FC2C57A67700B73AF0 /* CapacityCalculator.swift */; };
+		1BC4CF962C606B190012B7F0 /* CustomNumPad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC4CF952C606B190012B7F0 /* CustomNumPad.swift */; };
 		1BF858BA2C5B75A200C2204E /* CapacitySettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF858B42C5B75A200C2204E /* CapacitySettingView.swift */; };
 		1BF858BB2C5B75A200C2204E /* CapacityDirectInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF858B52C5B75A200C2204E /* CapacityDirectInputView.swift */; };
 		1BF858BC2C5B75A200C2204E /* CustomSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF858B62C5B75A200C2204E /* CustomSlider.swift */; };
@@ -105,6 +106,7 @@
 		1BAAB4F62C576CCF00B73AF0 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		1BAAB4FA2C57872600B73AF0 /* VideoFormatCapacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFormatCapacity.swift; sourceTree = "<group>"; };
 		1BAAB4FC2C57A67700B73AF0 /* CapacityCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapacityCalculator.swift; sourceTree = "<group>"; };
+		1BC4CF952C606B190012B7F0 /* CustomNumPad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNumPad.swift; sourceTree = "<group>"; };
 		1BF858B42C5B75A200C2204E /* CapacitySettingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CapacitySettingView.swift; sourceTree = "<group>"; };
 		1BF858B52C5B75A200C2204E /* CapacityDirectInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CapacityDirectInputView.swift; sourceTree = "<group>"; };
 		1BF858B62C5B75A200C2204E /* CustomSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSlider.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				1BF858B42C5B75A200C2204E /* CapacitySettingView.swift */,
 				1BF858B62C5B75A200C2204E /* CustomSlider.swift */,
 				1BF858B72C5B75A200C2204E /* TipView.swift */,
+				1BC4CF952C606B190012B7F0 /* CustomNumPad.swift */,
 			);
 			path = SelectCapacity;
 			sourceTree = "<group>";
@@ -548,6 +551,7 @@
 				26BAEFA22C5BAD8500346BF6 /* OnboardingView.swift in Sources */,
 				260035C92C57792000343511 /* UserProfileCreationView.swift in Sources */,
 				260035DC2C580D4C00343511 /* UserProfileInputModel.swift in Sources */,
+				1BC4CF962C606B190012B7F0 /* CustomNumPad.swift in Sources */,
 				1EEF415C2C5BCAA40078CD21 /* MyFavoriteIdolCardView.swift in Sources */,
 				1BF858BA2C5B75A200C2204E /* CapacitySettingView.swift in Sources */,
 				260035D52C57F1AB00343511 /* UserProfileTextInputPageView.swift in Sources */,

--- a/MoonCrystal/MoonCrystal/FormatInputView/FormatInputView.swift
+++ b/MoonCrystal/MoonCrystal/FormatInputView/FormatInputView.swift
@@ -14,6 +14,7 @@ struct FormatInputView: View {
     @State var isHighQualitySelected = false
     
     var favoriteIdol: String
+    var totalCapacity: Int
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,7 +40,7 @@ struct FormatInputView: View {
             .padding(.top, 34)
             NavigationLink {
                 if let selectedType {
-                    CapacitySettingView(path: $path, videoFormat: selectedType, favoriteIdol: favoriteIdol)
+                    CapacitySettingView(path: $path, totalCapacity: totalCapacity, videoFormat: selectedType, favoriteIdol: favoriteIdol)
                 }
             } label: {
                 RoundedRectangle(cornerRadius: 12)

--- a/MoonCrystal/MoonCrystal/MainHomeView/MainHomeView.swift
+++ b/MoonCrystal/MoonCrystal/MainHomeView/MainHomeView.swift
@@ -63,7 +63,7 @@ struct MainHomeView: View {
             .edgesIgnoringSafeArea(.all)
             .navigationDestination(for: String.self) { pathValue in
                 if pathValue == "FormatInput" {
-                    FormatInputView(path: $navPath, favoriteIdol: userProfile.first?.favoriteIdol ?? "최애")
+                    FormatInputView(path: $navPath, favoriteIdol: userProfile.first?.favoriteIdol ?? "최애", totalCapacity: Int(totalCapacity.byteToGB()))
                 } else if pathValue == "CleanUpView" {
                     CapacityCleanupView(path: $navPath, userProfile: userProfile.first)
                 }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
@@ -14,7 +14,7 @@ struct CapacityDirectInputView: View {
     @State var tempCapacity = 0
     @State var text = ""
     
-    var totalCapacity: Int = 127
+    var totalCapacity: Int
     var favoriteIdol = "최애"
     let title = "를 위해 \n몇 GB 정리할까요?"
     let alertMessage = "휴대폰 용량을 초과했어요"
@@ -92,8 +92,4 @@ struct CapacityDirectInputView: View {
             CustomNumPad(selectedNumber: $tempCapacity)
         }
     }
-}
-
-#Preview {
-    ContentView()
 }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
@@ -11,7 +11,7 @@ struct CapacityDirectInputView: View {
     @Environment(\.dismiss) var dismiss
     @FocusState private var isFocused: Bool
     @Binding var selectedCapacity: Double
-    @State var tempCapacity: String = "0"
+    @State var tempCapacity = 0
     @State var text = ""
     
     var totalCapacity: Int = 127
@@ -27,24 +27,26 @@ struct CapacityDirectInputView: View {
                     dismiss()
                 } label: {
                     Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .semibold))
                         .frame(height: 30)
                 }
                 .tint(.gray900)
             }
             .padding(.horizontal, 20)
             .padding(.top, 14)
-            .padding(.bottom, 22)
+            .padding(.bottom, 2)
             
             Text(favoriteIdol + title)
                 .font(.system(size: 24, weight: .semibold))
+                .frame(height: 67)
                 .foregroundColor(.gray900)
-                .padding(.bottom, 11)
+                .padding(.bottom, 31)
                 .padding(.leading, 24)
                 .fixedSize()
             
             Text(alertMessage)
                 .font(.system(size: 14))
-                .foregroundStyle(Int(tempCapacity) ?? 0 <= totalCapacity ? .clear : .pink300)
+                .foregroundStyle(tempCapacity <= totalCapacity ? .clear : .pink300)
                 .padding(.leading, 24)
                 .padding(.bottom, 8)
             
@@ -59,8 +61,10 @@ struct CapacityDirectInputView: View {
                     .font(.system(size: 34, weight: .semibold))
                     .padding(.trailing, 41)
             }
+            .frame(height: 41)
             .foregroundStyle(.gray700)
             .padding(.leading, 22)
+            .padding(.bottom, 5.5)
             
             Rectangle()
                 .frame(height: 1)
@@ -69,13 +73,13 @@ struct CapacityDirectInputView: View {
                 .foregroundStyle(.pink300)
             
             Button {
-                if Int(tempCapacity) ?? 0 <= totalCapacity {
-                    selectedCapacity = Double(tempCapacity) ?? selectedCapacity
+                if tempCapacity <= totalCapacity {
+                    selectedCapacity = Double(tempCapacity)
                     dismiss()
                 }
             } label: {
                 Rectangle()
-                    .foregroundStyle(Int(tempCapacity) ?? 0 <= totalCapacity ? .gray900 : .gray400)
+                    .foregroundStyle(tempCapacity <= totalCapacity ? .gray900 : .gray400)
                     .frame(height: 65)
                     .overlay {
                         Text("확인")
@@ -83,8 +87,9 @@ struct CapacityDirectInputView: View {
                             .foregroundStyle(Color.white)
                     }
             }
-            .padding(.top, 16)
-            CustomNumPad(string: $tempCapacity)
+            .padding(.top, 20)
+            
+            CustomNumPad(selectedNumber: $tempCapacity)
         }
     }
 }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
@@ -11,7 +11,7 @@ struct CapacityDirectInputView: View {
     @Environment(\.dismiss) var dismiss
     @FocusState private var isFocused: Bool
     @Binding var selectedCapacity: Double
-    @State var tempCapacity: Double = 0.0
+    @State var tempCapacity: String = "0"
     @State var text = ""
     
     var fullCapacity: Int = 127
@@ -45,16 +45,16 @@ struct CapacityDirectInputView: View {
             
             Text(alertMessage)
                 .font(.system(size: 14))
-                .foregroundStyle(Int(tempCapacity) < fullCapacity ? .clear : .pink300)
+                .foregroundStyle(Int(tempCapacity) ?? 0 < fullCapacity ? .clear : .pink300)
                 .padding(.leading, 24)
                 .padding(.bottom, 8)
             
             HStack {
-                TextField("0", value: $tempCapacity, formatter: NumberFormatter())
-                    .keyboardType(.numberPad)
-                    .font(.system(size: 34, weight: .semibold))
-                    .focused($isFocused)
-                
+                ScrollView(.horizontal, showsIndicators: false) {
+                    Text("\(tempCapacity)")
+                        .font(.system(size: 34, weight: .semibold))
+                }
+                .defaultScrollAnchor(.trailing)
                 Spacer()
                 Text("GB")
                     .font(.system(size: 34, weight: .semibold))
@@ -70,13 +70,13 @@ struct CapacityDirectInputView: View {
                 .foregroundStyle(.pink300)
             
             Button {
-                if Int(tempCapacity) < fullCapacity {
-                    selectedCapacity = tempCapacity
+                if Int(tempCapacity) ?? 0 < fullCapacity {
+                    selectedCapacity = Double(tempCapacity) ?? selectedCapacity
                     dismiss()
                 }
             } label: {
                 Rectangle()
-                    .foregroundStyle(Int(tempCapacity) < fullCapacity ? .gray900 : .gray400)
+                    .foregroundStyle(Int(tempCapacity) ?? 0 < fullCapacity ? .gray900 : .gray400)
                     .frame(height: 65)
                     .overlay {
                         Text("확인")
@@ -85,11 +85,11 @@ struct CapacityDirectInputView: View {
                     }
             }
             .padding(.top, 16)
-        }
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                isFocused = true
-            }
+            CustomNumPad(string: $tempCapacity)
         }
     }
+}
+
+#Preview {
+    ContentView()
 }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
@@ -14,7 +14,7 @@ struct CapacityDirectInputView: View {
     @State var tempCapacity: String = "0"
     @State var text = ""
     
-    var fullCapacity: Int = 127
+    var totalCapacity: Int = 127
     var favoriteIdol = "최애"
     let title = "를 위해 \n몇 GB 정리할까요?"
     let alertMessage = "휴대폰 용량을 초과했어요"
@@ -35,7 +35,6 @@ struct CapacityDirectInputView: View {
             .padding(.top, 14)
             .padding(.bottom, 22)
             
-            
             Text(favoriteIdol + title)
                 .font(.system(size: 24, weight: .semibold))
                 .foregroundColor(.gray900)
@@ -45,7 +44,7 @@ struct CapacityDirectInputView: View {
             
             Text(alertMessage)
                 .font(.system(size: 14))
-                .foregroundStyle(Int(tempCapacity) ?? 0 < fullCapacity ? .clear : .pink300)
+                .foregroundStyle(Int(tempCapacity) ?? 0 <= totalCapacity ? .clear : .pink300)
                 .padding(.leading, 24)
                 .padding(.bottom, 8)
             
@@ -70,13 +69,13 @@ struct CapacityDirectInputView: View {
                 .foregroundStyle(.pink300)
             
             Button {
-                if Int(tempCapacity) ?? 0 < fullCapacity {
+                if Int(tempCapacity) ?? 0 <= totalCapacity {
                     selectedCapacity = Double(tempCapacity) ?? selectedCapacity
                     dismiss()
                 }
             } label: {
                 Rectangle()
-                    .foregroundStyle(Int(tempCapacity) ?? 0 < fullCapacity ? .gray900 : .gray400)
+                    .foregroundStyle(Int(tempCapacity) ?? 0 <= totalCapacity ? .gray900 : .gray400)
                     .frame(height: 65)
                     .overlay {
                         Text("확인")

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
@@ -16,6 +16,7 @@ struct CapacitySettingView: View {
     @State var showTip = false
     @State var keyboardHeight : CGFloat = 0
     
+    var totalCapacity : Int
     var videoFormat: VideoFormatCapacity = .defaultQuality
     var favoriteIdol: String
     ///Slider의 max값을 결정하는 변수입니다.
@@ -137,7 +138,7 @@ struct CapacitySettingView: View {
             .ignoresSafeArea(.keyboard)
         }
         .sheet(isPresented: $useDirectInput) {
-            CapacityDirectInputView(selectedCapacity: $selectedCapacity, tempCapacity: String(Int(selectedCapacity)))
+            CapacityDirectInputView(selectedCapacity: $selectedCapacity, tempCapacity: String(Int(selectedCapacity)), totalCapacity: totalCapacity)
                 .presentationDetents([.height(550)])
                 .presentationDragIndicator(.visible)
         }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
@@ -137,8 +137,8 @@ struct CapacitySettingView: View {
             .ignoresSafeArea(.keyboard)
         }
         .sheet(isPresented: $useDirectInput) {
-            CapacityDirectInputView(selectedCapacity: $selectedCapacity, tempCapacity: selectedCapacity.rounded(.down))
-                .presentationDetents([.height(250)])
+            CapacityDirectInputView(selectedCapacity: $selectedCapacity, tempCapacity: String(Int(selectedCapacity)))
+                .presentationDetents([.height(550)])
                 .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showTip) {

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
@@ -138,8 +138,8 @@ struct CapacitySettingView: View {
             .ignoresSafeArea(.keyboard)
         }
         .sheet(isPresented: $useDirectInput) {
-            CapacityDirectInputView(selectedCapacity: $selectedCapacity, tempCapacity: String(Int(selectedCapacity)), totalCapacity: totalCapacity)
-                .presentationDetents([.height(550)])
+            CapacityDirectInputView(selectedCapacity: $selectedCapacity, tempCapacity: Int(selectedCapacity), totalCapacity: totalCapacity)
+                .presentationDetents([.height(588)])
                 .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showTip) {

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CustomNumPad.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CustomNumPad.swift
@@ -7,17 +7,17 @@
 
 import SwiftUI
 
-struct CustomNumPad : View {
-    @Binding var string : String
-    let maxDigits : Int = 18
+struct CustomNumPad: View {
+    @Binding var selectedNumber: Int
+    let maxDigits: Int = 18
     
     var body: some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading, spacing: 6) {
-                NumPadRow(keys: ["1", "2", "3"], action: keyWasPressed(_:))
-                NumPadRow(keys: ["4", "5", "6"], action: keyWasPressed(_:))
-                NumPadRow(keys: ["7", "8", "9"], action: keyWasPressed(_:))
-                NumPadRow(keys: ["", "0", "⌫"], action: keyWasPressed(_:))
+                NumPadRow(keys: [.one, .two, .three], action: keyWasPressed(_:))
+                NumPadRow(keys: [.four, .five, .six], action: keyWasPressed(_:))
+                NumPadRow(keys: [.seven, .eight, .nine], action: keyWasPressed(_:))
+                NumPadRow(keys: [.none, .zero, .backspace], action: keyWasPressed(_:))
             }
             .padding(.top, 6)
             Spacer()
@@ -25,28 +25,49 @@ struct CustomNumPad : View {
         .frame(height: 291.0)
         .background(Color(red: 0.81, green: 0.82, blue: 0.84))
     }
-    
-    private func keyWasPressed(_ key: String) {
-        if ( string.trimmingCharacters(in: .whitespacesAndNewlines).count > maxDigits-1 && key != "⌫" ) {
-            print("❌ Over the max digit for Int64 \(string.count) ")
+    private func keyWasPressed(_ key: NumPadKey) {
+        if String(selectedNumber).count > maxDigits-1 && key != .backspace {
+            print("❌ Over the max digit for Int64 \(selectedNumber)")
             return
         }
         switch key {
-        case "⌫":
-            if string.isEmpty { string = "0" } else {
-                string.removeLast()
-            }
-            if string.isEmpty { string = "0" }
-        case "" : return
-        case _ where string == "0": string = key
-        default: string += key
+        case .backspace:
+        if selectedNumber != 0 {
+            selectedNumber /= 10
+        }
+        case .none: return
+        case _ where selectedNumber == 0 : selectedNumber = key.rawValue
+        default: selectedNumber = selectedNumber * 10 + key.rawValue
+        }
+    }
+}
+
+enum NumPadKey: Int {
+    case zero = 0, one, two, three, four, five, six, seven, eight, nine
+    case backspace = -1
+    case none = -2
+    
+    var description: String {
+        switch self {
+        case .zero: return "0"
+        case .one: return "1"
+        case .two: return "2"
+        case .three: return "3"
+        case .four: return "4"
+        case .five: return "5"
+        case .six: return "6"
+        case .seven: return "7"
+        case .eight: return "8"
+        case .nine: return "9"
+        case .backspace: return "⌫"
+        case .none: return ""
         }
     }
 }
 
 struct NumPadRow: View {
-    var keys: [String]
-    var action : (String) -> Void
+    var keys: [NumPadKey]
+    var action: (NumPadKey) -> Void
     
     var body: some View {
         HStack{
@@ -60,25 +81,24 @@ struct NumPadRow: View {
 }
 
 struct NumPadButton: View {
-    var key : String
-    var action : (String) -> Void
+    var key: NumPadKey
+    var action: (NumPadKey) -> Void
     
     var body: some View {
         Button {
             self.action(self.key)
-        } label : {
+        } label: {
             HStack(spacing: 0){
                 Spacer()
-                Text(key)
-                    .font(key == "⌫" ? .system(size: 28) : .system(size: 25) )
+                Text(key.description)
+                    .font(key == .backspace ? .system(size: 28) : .system(size: 25))
                     .foregroundColor(.black)
                 Spacer()
-            }.frame(height: 46.0)
-                .accessibilityIdentifier("keyPadButton\(self.key)")
-                .background(RoundedRectangle(cornerRadius: 5)
-                    .fill(key != "" && key != "⌫" ? Color(red: 0.99, green: 0.99, blue: 1) : Color.clear )
-                    .shadow(color: Color(red: 0.54, green: 0.54, blue: 0.55), radius: 0, x: 0, y: 1)
-                )
+            }
+            .frame(height: 46.0)
+            .background(RoundedRectangle(cornerRadius: 5)
+            .fill(key != .none && key != .backspace ? Color(red: 0.99, green: 0.99, blue: 1) : Color.clear )
+            .shadow(color: Color(red: 0.54, green: 0.54, blue: 0.55), radius: 0, x: 0, y: 1))
         }
     }
 }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CustomNumPad.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CustomNumPad.swift
@@ -1,0 +1,84 @@
+//
+//  CustomNumpad.swift
+//  MoonCrystal
+//
+//  Created by seonu kim on 8/5/24.
+//
+
+import SwiftUI
+
+struct CustomNumPad : View {
+    @Binding var string : String
+    let maxDigits : Int = 18
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 6) {
+                NumPadRow(keys: ["1", "2", "3"], action: keyWasPressed(_:))
+                NumPadRow(keys: ["4", "5", "6"], action: keyWasPressed(_:))
+                NumPadRow(keys: ["7", "8", "9"], action: keyWasPressed(_:))
+                NumPadRow(keys: ["", "0", "⌫"], action: keyWasPressed(_:))
+            }
+            .padding(.top, 6)
+            Spacer()
+        }
+        .frame(height: 291.0)
+        .background(Color(red: 0.81, green: 0.82, blue: 0.84))
+    }
+    
+    private func keyWasPressed(_ key: String) {
+        if ( string.trimmingCharacters(in: .whitespacesAndNewlines).count > maxDigits-1 && key != "⌫" ) {
+            print("❌ Over the max digit for Int64 \(string.count) ")
+            return
+        }
+        switch key {
+        case "⌫":
+            if string.isEmpty { string = "0" } else {
+                string.removeLast()
+            }
+            if string.isEmpty { string = "0" }
+        case "" : return
+        case _ where string == "0": string = key
+        default: string += key
+        }
+    }
+}
+
+struct NumPadRow: View {
+    var keys: [String]
+    var action : (String) -> Void
+    
+    var body: some View {
+        HStack{
+            ForEach(keys, id: \.self) { item in
+                NumPadButton(key: item, action: self.action)
+                    .padding(.leading, 6)
+                    .padding(.trailing, item == keys.last ? 6 : 0)
+            }
+        }
+    }
+}
+
+struct NumPadButton: View {
+    var key : String
+    var action : (String) -> Void
+    
+    var body: some View {
+        Button {
+            self.action(self.key)
+        } label : {
+            HStack(spacing: 0){
+                Spacer()
+                Text(key)
+                    .font(key == "⌫" ? .system(size: 28) : .system(size: 25) )
+                    .foregroundColor(.black)
+                Spacer()
+            }.frame(height: 46.0)
+                .accessibilityIdentifier("keyPadButton\(self.key)")
+                .background(RoundedRectangle(cornerRadius: 5)
+                    .fill(key != "" && key != "⌫" ? Color(red: 0.99, green: 0.99, blue: 1) : Color.clear )
+                    .shadow(color: Color(red: 0.54, green: 0.54, blue: 0.55), radius: 0, x: 0, y: 1)
+                )
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 커스텀 키보드를 화면에 추가하고, 총용량을 변수로 홈화면부터 연결함

### 스크린샷 (선택)
<img width="421" alt="스크린샷 2024-08-05 오후 4 13 42" src="https://github.com/user-attachments/assets/5c488bd3-5861-43d7-a1ed-0bb1ebd67f31">
키보드 모양은 이렇습니다!

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
