### PR TITLE
[#53] 프로필 화면 데이터를 capacitySettingView와 tipView로 연결

### DIFF
--- a/MoonCrystal/MoonCrystal/FormatInputView/FormatInputView.swift
+++ b/MoonCrystal/MoonCrystal/FormatInputView/FormatInputView.swift
@@ -15,6 +15,7 @@ struct FormatInputView: View {
     
     var favoriteIdol: String
     var totalCapacity: Int
+    var profileImage: Data?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -40,7 +41,7 @@ struct FormatInputView: View {
             .padding(.top, 34)
             NavigationLink {
                 if let selectedType {
-                    CapacitySettingView(path: $path, totalCapacity: totalCapacity, videoFormat: selectedType, favoriteIdol: favoriteIdol)
+                    CapacitySettingView(path: $path, totalCapacity: totalCapacity, videoFormat: selectedType, favoriteIdol: favoriteIdol, profileImage: profileImage)
                 }
             } label: {
                 RoundedRectangle(cornerRadius: 12)

--- a/MoonCrystal/MoonCrystal/MainHomeView/MainHomeView.swift
+++ b/MoonCrystal/MoonCrystal/MainHomeView/MainHomeView.swift
@@ -63,7 +63,7 @@ struct MainHomeView: View {
             .edgesIgnoringSafeArea(.all)
             .navigationDestination(for: String.self) { pathValue in
                 if pathValue == "FormatInput" {
-                    FormatInputView(path: $navPath, favoriteIdol: userProfile.first?.favoriteIdol ?? "최애", totalCapacity: Int(totalCapacity.byteToGB()))
+                    FormatInputView(path: $navPath, favoriteIdol: userProfile.first?.favoriteIdol ?? "최애", totalCapacity: Int(totalCapacity.byteToGB()), profileImage: userProfile.first?.image)
                 } else if pathValue == "CleanUpView" {
                     CapacityCleanupView(path: $navPath, userProfile: userProfile.first)
                 }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
@@ -15,7 +15,7 @@ struct CapacityDirectInputView: View {
     @State var text = ""
     
     var totalCapacity: Int
-    var favoriteIdol = "최애"
+    var favoriteIdol: String
     let title = "를 위해 \n몇 GB 정리할까요?"
     let alertMessage = "휴대폰 용량을 초과했어요"
     
@@ -54,15 +54,16 @@ struct CapacityDirectInputView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     Text("\(tempCapacity)")
                         .font(.system(size: 34, weight: .semibold))
+                        .foregroundStyle(tempCapacity == 0 ? .gray400 : .gray700)
                 }
                 .defaultScrollAnchor(.trailing)
                 Spacer()
                 Text("GB")
                     .font(.system(size: 34, weight: .semibold))
                     .padding(.trailing, 41)
+                    .foregroundStyle(.gray700)
             }
             .frame(height: 41)
-            .foregroundStyle(.gray700)
             .padding(.leading, 22)
             .padding(.bottom, 5.5)
             

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
@@ -19,6 +19,8 @@ struct CapacitySettingView: View {
     var totalCapacity : Int
     var videoFormat: VideoFormatCapacity = .defaultQuality
     var favoriteIdol: String
+    var profileImage: Data?
+    
     ///Slider의 max값을 결정하는 변수입니다.
     var maxCapacity: Double {
         if videoFormat == .defaultQuality {
@@ -138,12 +140,12 @@ struct CapacitySettingView: View {
             .ignoresSafeArea(.keyboard)
         }
         .sheet(isPresented: $useDirectInput) {
-            CapacityDirectInputView(selectedCapacity: $selectedCapacity, tempCapacity: Int(selectedCapacity), totalCapacity: totalCapacity)
+            CapacityDirectInputView(selectedCapacity: $selectedCapacity, tempCapacity: Int(selectedCapacity), totalCapacity: totalCapacity, favoriteIdol: favoriteIdol)
                 .presentationDetents([.height(588)])
                 .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showTip) {
-            TipView()
+            TipView(profileImage: profileImage)
                 .presentationDetents([.height(476)])
                 .presentationDragIndicator(.visible)
         }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/TipView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/TipView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct TipView: View {
     @Environment(\.dismiss) var dismiss
     let title = "정리를 시작하기 전,\n얼마나 삭제할 지 감이 안 온다면?"
+    var profileImage: Data?
     
     var body: some View {
         ZStack {
@@ -48,7 +49,7 @@ struct TipView: View {
                     .padding(.trailing, 20)
                     
                     //나중에 이미지 연결할 때 이미지데이터 넣어주세요.
-                    circleIcon(image: nil)
+                    circleIcon(image: profileImage)
                         .frame(height: 72)
                         .offset(x: -48, y: -32)
                     
@@ -98,9 +99,10 @@ struct TipView: View {
             if let image = image, let uiimage = UIImage(data: image) {
                 Image(uiImage: uiimage)
                     .resizable()
-                    .scaledToFit()
+                    .scaledToFill()
                     .clipShape(Circle())
-                    .frame(width: 63)
+                    .padding(4.5)
+                    .frame(width: 72)
             } else {
                 Circle()
                     .frame(height: 72)
@@ -117,8 +119,4 @@ struct TipView: View {
                 .padding(1)
         }
     }
-}
-
-#Preview {
-    TipView()
 }


### PR DESCRIPTION
## 📝 작업 내용
- 용량 설정 화면의 아이돌이 다이렉트 인풋 화면으로 연동되도록 설정함
- 프로필의 설정 이미지가 tipView의 이미지로 연동되도록 설정함
- 용량 직접 입력 화면에서 입력값이 0일 때 text가 회색으로 표시되도록 설정

### 스크린샷 (선택)
<img width="399" alt="스크린샷 2024-08-06 오후 3 55 42" src="https://github.com/user-attachments/assets/144d1ae2-c174-4df6-9432-0053dfb27dfc">
<img width="409" alt="스크린샷 2024-08-06 오후 3 57 09" src="https://github.com/user-attachments/assets/8859c688-315a-4dec-9d05-775b11555c07">


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
