### PR TITLE
[#59] 정리하기뷰에서 정리한 시간 표현방식 수정

### DIFF
--- a/MoonCrystal/MoonCrystal/CleanupView/CapacityCleanupView.swift
+++ b/MoonCrystal/MoonCrystal/CleanupView/CapacityCleanupView.swift
@@ -25,7 +25,7 @@ struct CapacityCleanupView: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text("지금까지 \(MediaCapacityConverter.capacityToTime(capacity: cleanUpCapacity, format: seletedVideoFormat))분(\(cleanUpCapacity.byteToGBStr(format: "%.1f"))GB)\n확보했어요")
+                Text("지금까지 \(MediaCapacityConverter.capacityToHourAndMinute(capacity: cleanUpCapacity, format: seletedVideoFormat))(\(cleanUpCapacity.byteToGBStr(format: "%.1f"))GB)\n확보했어요")
                     .foregroundStyle(.gray900)
                     .font(.system(size: 28, weight: .semibold))
                     .multilineTextAlignment(.leading)

--- a/MoonCrystal/MoonCrystal/MediaCapacityConverter.swift
+++ b/MoonCrystal/MoonCrystal/MediaCapacityConverter.swift
@@ -7,8 +7,17 @@
 
 /// 남은 잔여 용량을 비디오 촬영시간 또는 촬영 가능 사진 수로 반환하는 함수들의 class입니다.
 class MediaCapacityConverter {
-    static func capacityToTime(capacity: Int, format: VideoFormatCapacity) -> Int {
+    static func capacityToMinute(capacity: Int, format: VideoFormatCapacity) -> Int {
         return capacity / format.rawValue
+    }
+    
+    static func capacityToHourAndMinute(capacity: Int, format: VideoFormatCapacity) -> String {
+        let minute = capacity / format.rawValue
+        switch minute {
+        case 0..<60 : return "\(minute)분"
+        case let x where x % 60 == 0 : return "\(x / 60)시간"
+        default: return "\(minute / 60)시간 \(minute % 60)분"
+        }
     }
     
     static func capacityToPhoto(capacity: Int) -> Int {
@@ -16,7 +25,7 @@ class MediaCapacityConverter {
     }
     
     static func getavailableTimeText(capacity: Int, format: VideoFormatCapacity) -> String{
-        let availableTime = capacityToTime(capacity: capacity, format: format)
+        let availableTime = capacityToMinute(capacity: capacity, format: format)
         var availableTimeText = ""
         
         availableTimeText += String(availableTime.minutesToHoursAndMinutes().hours)

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
@@ -39,7 +39,7 @@ struct CapacitySettingView: View {
         return MediaCapacityConverter.capacityToPhoto(capacity: Int(selectedCapacity) * 1_073_741_824)
     }
     var videoTime: Int {
-        return MediaCapacityConverter.capacityToTime(capacity: Int(selectedCapacity) * 1_073_741_824, format: videoFormat)
+        return MediaCapacityConverter.capacityToMinute(capacity: Int(selectedCapacity) * 1_073_741_824, format: videoFormat)
     }
     let title = "를 위해 \n몇 GB 정리할까요?"
     let ment = "촬영할 수 있어요"


### PR DESCRIPTION
## 📝 작업 내용
- 기존에 있는 분을 반환하는 함수 이름을 CapacityToMinute으로 수정함
- 시간과 분을 시간과 분 부분의 유무에 맞춰 함께 String Type으로 반환하는 func을 추가함

### 스크린샷 (선택)
<img width="290" alt="스크린샷 2024-08-07 오전 11 22 52" src="https://github.com/user-attachments/assets/7695878a-bfa1-4b50-8324-e36e3d851ad2">
<br>분단위 없을 때 시간만, 시간단위 없을 때 분만 보이도록 설정함<br>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
