### PR TITLE
[#69] 종성에 따른 을/를 표기변환 코드추가

### DIFF
--- a/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
+++ b/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		1EAA7F232C5F6F9100BF140D /* MediaCapacityConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAAB4EE2C54D7E400B73AF0 /* MediaCapacityConverter.swift */; };
 		1EAA7F242C5F70CA00BF140D /* VideoFormatCapacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAAB4FA2C57872600B73AF0 /* VideoFormatCapacity.swift */; };
 		1EAA7F252C5F722000BF140D /* UserDefaultsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB4BE962C5F3E8B00BEE5DB /* UserDefaultsKeys.swift */; };
+		1EAEBAD12C647AEA00D6C28A /* JosaFomatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EAEBAD02C647AEA00D6C28A /* JosaFomatter.swift */; };
+		1EAEBAD22C64817100D6C28A /* JosaFomatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EAEBAD02C647AEA00D6C28A /* JosaFomatter.swift */; };
 		1EB4BE972C5F3E8B00BEE5DB /* UserDefaultsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB4BE962C5F3E8B00BEE5DB /* UserDefaultsKeys.swift */; };
 		1ED6C0672C5E41BF007D9C71 /* DynamicIslandButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED6C0662C5E41BF007D9C71 /* DynamicIslandButtonsView.swift */; };
 		1EEF41482C5A1CF50078CD21 /* FormatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEF41472C5A1CF50078CD21 /* FormatInputView.swift */; };
@@ -131,6 +133,7 @@
 		1E87A6D72C593D7300BD28D1 /* MainHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHomeView.swift; sourceTree = "<group>"; };
 		1EAA7F262C5F744C00BF140D /* MoonCrystal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MoonCrystal.entitlements; sourceTree = "<group>"; };
 		1EAA7F272C5F749100BF140D /* MoonCrystalWidgetExtentionExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MoonCrystalWidgetExtentionExtension.entitlements; sourceTree = "<group>"; };
+		1EAEBAD02C647AEA00D6C28A /* JosaFomatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JosaFomatter.swift; sourceTree = "<group>"; };
 		1EB4BE962C5F3E8B00BEE5DB /* UserDefaultsKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKeys.swift; sourceTree = "<group>"; };
 		1ED6C0662C5E41BF007D9C71 /* DynamicIslandButtonsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicIslandButtonsView.swift; sourceTree = "<group>"; };
 		1EEF41472C5A1CF50078CD21 /* FormatInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatInputView.swift; sourceTree = "<group>"; };
@@ -240,6 +243,14 @@
 				1E87A6D72C593D7300BD28D1 /* MainHomeView.swift */,
 			);
 			path = MainHomeView;
+			sourceTree = "<group>";
+		};
+		1EAEBACF2C647AC700D6C28A /* JosaFomatter */ = {
+			isa = PBXGroup;
+			children = (
+				1EAEBAD02C647AEA00D6C28A /* JosaFomatter.swift */,
+			);
+			path = JosaFomatter;
 			sourceTree = "<group>";
 		};
 		1EB4BE952C5F3E8100BEE5DB /* UserDefaultsKeys */ = {
@@ -377,6 +388,7 @@
 				1BAAB4EE2C54D7E400B73AF0 /* MediaCapacityConverter.swift */,
 				1BAAB4F62C576CCF00B73AF0 /* Int+Extension.swift */,
 				1BAAB4FA2C57872600B73AF0 /* VideoFormatCapacity.swift */,
+				1EAEBACF2C647AC700D6C28A /* JosaFomatter */,
 				1EEF41582C5BB0820078CD21 /* DeletedTotalCapacityView */,
 				1EEF41462C5A1CD60078CD21 /* FormatInputView */,
 				1E87A6D22C593D1800BD28D1 /* MainHomeView */,
@@ -536,6 +548,7 @@
 				1E26D7272C62583D007E6059 /* LocalNotificationType.swift in Sources */,
 				1E55934E2C53800B00C78466 /* MoonCrystalWidgetExtentionLiveActivity.swift in Sources */,
 				1E26D72B2C625A6D007E6059 /* requestNotification.swift in Sources */,
+				1EAEBAD22C64817100D6C28A /* JosaFomatter.swift in Sources */,
 				1EAA7F232C5F6F9100BF140D /* MediaCapacityConverter.swift in Sources */,
 				1E356AD42C5CC82500869711 /* LiveActivitySaveTimeView.swift in Sources */,
 				1ED6C0672C5E41BF007D9C71 /* DynamicIslandButtonsView.swift in Sources */,
@@ -573,6 +586,7 @@
 				260035D52C57F1AB00343511 /* UserProfileTextInputPageView.swift in Sources */,
 				1BF858BD2C5B75A200C2204E /* TipView.swift in Sources */,
 				1EEF415E2C5BDC080078CD21 /* EndCleanUpView.swift in Sources */,
+				1EAEBAD12C647AEA00D6C28A /* JosaFomatter.swift in Sources */,
 				260035E02C5928D000343511 /* PhotoPickerButton.swift in Sources */,
 				1EEF415A2C5BB0B00078CD21 /* DeletedTotalCapacityView.swift in Sources */,
 				26C965C92C5241F8000257EA /* MoonCrystalApp.swift in Sources */,

--- a/MoonCrystal/MoonCrystal/CleanupView/CapacityCleanupView.swift
+++ b/MoonCrystal/MoonCrystal/CleanupView/CapacityCleanupView.swift
@@ -35,7 +35,7 @@ struct CapacityCleanupView: View {
             .padding(.top, 66)
             
             VStack(spacing: 38) {
-                Text("\(userProfile?.favoriteIdol ?? "최애")를 위해 정리중 ...")
+                Text("\(JosaFomatter.postPositionText(userProfile?.favoriteIdol ?? "최애")) 위해 정리중 ...")
                     .foregroundStyle(.gray600)
                     .font(.system(size: 15, weight: .regular))
                 

--- a/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/MyFavoriteIdolCardView.swift
+++ b/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/MyFavoriteIdolCardView.swift
@@ -75,7 +75,7 @@ struct MyFavoriteIdolCardView : View {
     var cardDescription: some View {
         HStack {
             VStack(alignment: .leading) {
-                Text("지금까지 \(userProfile?.favoriteIdol ?? "최애")를 위해")
+                Text("지금까지 \(JosaFomatter.postPositionText(userProfile?.favoriteIdol ?? "최애")) 위해")
                     .font(.system(size: 16))
                     .foregroundStyle(.white)
                 HStack(spacing: 0) {

--- a/MoonCrystal/MoonCrystal/JosaFomatter/JosaFomatter.swift
+++ b/MoonCrystal/MoonCrystal/JosaFomatter/JosaFomatter.swift
@@ -1,0 +1,25 @@
+//
+//  JosaFomatter.swift
+//  MoonCrystal
+//
+//  Created by sungkug_apple_developer_ac on 8/8/24.
+//
+
+import Foundation
+
+class JosaFomatter {
+    static func postPositionText(_ name: String) -> String {
+        guard let lastText = name.last else { return name }
+        // 유니코드 전환
+        let unicodeVal = UnicodeScalar(String(lastText))?.value
+        // 한글아니면 반환
+        guard let value = unicodeVal else { return name }
+        // 종성인지 확인
+        if (value < 0xAC00 || value > 0xD7A3) { return name }
+        // 받침있으면 을 없으면 를 반환
+        let last = (value - 0xAC00) % 28
+        
+        let str = last > 0 ? "을" : "를"
+        return name + str
+    }
+}

--- a/MoonCrystal/MoonCrystal/MainHomeView/MainHomeView.swift
+++ b/MoonCrystal/MoonCrystal/MainHomeView/MainHomeView.swift
@@ -157,7 +157,7 @@ struct MainHomeView: View {
     var availableTime: some View {
         HStack {
             VStack(alignment: .leading, spacing: 0.0) {
-                Text("\(userProfile.first?.favoriteIdol ?? "최애")\(MainHomeViewComponent.availableTime.title)")
+                Text("\(JosaFomatter.postPositionText(userProfile.first?.favoriteIdol ?? "최애"))\(MainHomeViewComponent.availableTime.title)")
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(Color.gray700)
                     .padding(.top, 38)

--- a/MoonCrystal/MoonCrystal/MainHomeView/MainHomeViewComponent.swift
+++ b/MoonCrystal/MoonCrystal/MainHomeView/MainHomeViewComponent.swift
@@ -16,7 +16,7 @@ enum MainHomeViewComponent {
         case .deletedStorage:
             return "최애를 위해 지금까지 지운 용량"
         case .availableTime:
-            return "를 촬영할 수 있는 시간"
+            return " 촬영할 수 있는 시간"
         case .currentCapacity:
             return "현재 저장 용량"
         case .CleanUpButton:

--- a/MoonCrystal/MoonCrystal/Notification/LocalNotificationType.swift
+++ b/MoonCrystal/MoonCrystal/Notification/LocalNotificationType.swift
@@ -21,7 +21,7 @@ enum NotificationType: String {
                 return ("Result Notification", "지금까지 정리된 내용을 확인할 수 없습니다.")
             }
             let title = "\(data)GB 정리 완료!"
-            let body = "지금까지 \(favoritIdol)를 위해 \(total)GB를 정리했어요"
+            let body = "지금까지 \(JosaFomatter.postPositionText(favoritIdol)) 위해 \(total)GB를 정리했어요"
             return (title, body)
         }
     }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacityDirectInputView.swift
@@ -16,7 +16,7 @@ struct CapacityDirectInputView: View {
     
     var totalCapacity: Int
     var favoriteIdol: String
-    let title = "를 위해 \n몇 GB 정리할까요?"
+    let title = " 위해 \n몇 GB 정리할까요?"
     let alertMessage = "휴대폰 용량을 초과했어요"
     
     var body: some View {
@@ -36,7 +36,7 @@ struct CapacityDirectInputView: View {
             .padding(.top, 14)
             .padding(.bottom, 2)
             
-            Text(favoriteIdol + title)
+            Text(JosaFomatter.postPositionText(favoriteIdol) + title)
                 .font(.system(size: 24, weight: .bold))
                 .frame(height: 67)
                 .foregroundColor(.gray900)

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
@@ -41,7 +41,7 @@ struct CapacitySettingView: View {
     var videoTime: Int {
         return MediaCapacityConverter.capacityToMinute(capacity: Int(selectedCapacity) * 1_073_741_824, format: videoFormat)
     }
-    let title = "를 위해 \n몇 GB 정리할까요?"
+    let title = " 위해 \n몇 GB 정리할까요?"
     let ment = "촬영할 수 있어요"
     
     var body: some View {
@@ -50,7 +50,7 @@ struct CapacitySettingView: View {
             VStack(spacing: 0) {
                 Spacer()
                 HStack {
-                    Text(favoriteIdol + title)
+                    Text(JosaFomatter.postPositionText(favoriteIdol) + title)
                         .font(.system(size: 28, weight: .bold))
                         .foregroundColor(.gray900)
                         .padding(.bottom, 54)


### PR DESCRIPTION
## 📝 작업 내용

> 종성에 따른 을/를 표기변환 코드추가, 영어는 을/를 없이 사용
> ex) 뉴진스를 위해, 방탄소년단을 위해, newjeans 위해 


