### PR TITLE
[#82] 리젝 해결하기: guideline 40 design

### DIFF
--- a/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
+++ b/MoonCrystal/MoonCrystal.xcodeproj/project.pbxproj
@@ -648,9 +648,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Horang.Fanbyte.FanbyteWidgetExtention;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -678,9 +682,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Horang.Fanbyte.FanbyteWidgetExtention;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -825,7 +833,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -865,7 +873,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/DeletedTotalCapacityView.swift
+++ b/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/DeletedTotalCapacityView.swift
@@ -21,7 +21,7 @@ struct DeletedTotalCapacityView: View {
                     .foregroundStyle(.gray900)
                 Spacer()
             }
-            .padding(.top, 120)
+            .padding(.top, 22)
             
             deletedTotalStatus
                 .frame(height: 60)
@@ -33,7 +33,7 @@ struct DeletedTotalCapacityView: View {
         }
         .padding(.horizontal)
         .background(.gray50)
-        .edgesIgnoringSafeArea(.all)
+        .edgesIgnoringSafeArea(.bottom)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button {

--- a/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/EndCleanUpView.swift
+++ b/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/EndCleanUpView.swift
@@ -48,6 +48,7 @@ struct EndCleanUpView: View {
                             .foregroundStyle(.white)
                     )
                     .padding(.top, 65)
+                    .padding(.bottom, 80)
             }
             Spacer()
         }

--- a/MoonCrystal/MoonCrystal/FormatInputView/FormatInputView.swift
+++ b/MoonCrystal/MoonCrystal/FormatInputView/FormatInputView.swift
@@ -19,12 +19,16 @@ struct FormatInputView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            Spacer()
             HStack {
                 Text("어떤 화질로\n촬영하실 건가요?")
                     .font(.system(size: 28, weight: .bold))
+                    .fixedSize()
                 Spacer()
             }
-            HStack() {
+            .padding(.top, 66)
+            
+            HStack {
                 formatButton(buttonName: "기본 화질", type: .defaultQuality)
                     .padding(.trailing, 9)
                 formatButton(buttonName: "고화질", type: nil)
@@ -40,9 +44,9 @@ struct FormatInputView: View {
             .frame(height: 260)
             .padding(.top, 34)
 
-            Button(action: {
+            Button {
                 self.path.append("SettingView")
-            }, label: {
+            } label: {
                 RoundedRectangle(cornerRadius: 12)
                     .frame(height: 68)
                     .foregroundStyle(selectedType == nil ? .gray400 : .gray900)
@@ -50,12 +54,11 @@ struct FormatInputView: View {
                         Text("\(selectedType ==  .defaultQuality ? "기본 화질" : "고화질")로 촬영할래요")
                             .font(.system(size: 15, weight: .regular))
                             .foregroundStyle(.white))
-            })
+            }
             .disabled(selectedType == nil)
             .padding(.top, 42)
             Spacer()
         }
-        .padding(.top, 164)
         .padding(.horizontal)
         .ignoresSafeArea()
         .background(.gray50)

--- a/MoonCrystal/MoonCrystal/MainHomeView/MainHomeView.swift
+++ b/MoonCrystal/MoonCrystal/MainHomeView/MainHomeView.swift
@@ -63,6 +63,7 @@ struct MainHomeView: View {
                 
                 Spacer()
             }
+            .padding(.bottom, 86)
             .background(.gray50)
             .edgesIgnoringSafeArea(.all)
             .navigationDestination(for: String.self) { pathValue in

--- a/MoonCrystal/MoonCrystal/OnoboardingView/OnboardingView.swift
+++ b/MoonCrystal/MoonCrystal/OnoboardingView/OnboardingView.swift
@@ -12,7 +12,7 @@ struct OnboardingView: View {
     @State private var currentStep: OnboardingStep = .first
     
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .center, spacing: 0) {
             TabView(selection: $currentStep) {
                 onboardingStepView(step: .first)
                     .tag(OnboardingStep.first)
@@ -24,7 +24,6 @@ struct OnboardingView: View {
                     .tag(OnboardingStep.third)
                 
             }
-            .padding(.top, 100)
             
             Button {
                 moveToNextStep()

--- a/MoonCrystal/MoonCrystal/OnoboardingView/onboardingStepView.swift
+++ b/MoonCrystal/MoonCrystal/OnoboardingView/onboardingStepView.swift
@@ -13,12 +13,13 @@ struct onboardingStepView: View {
     
     var body: some View {
         VStack(spacing: 0) {
+            Spacer()
             VStack(alignment: .leading, spacing: 16) {
                 HStack {
                     Text(step.title)
                         .font(.system(size: 28, weight: .bold))
                         .foregroundStyle(.gray900)
-
+                        .fixedSize()
                     Spacer()
                 }
                 
@@ -29,6 +30,7 @@ struct onboardingStepView: View {
                     Spacer()
                 }
             }
+//            .padding(.top, 100)
             
             LottieView(animation: .named(step.imageName))
                 .playing(loopMode: .loop)
@@ -47,7 +49,7 @@ struct onboardingStepView: View {
             }
             .padding(.top, 57)
         }
-        .frame(maxHeight: .infinity)
+//        .frame(maxHeight: .infinity)
         .background(.gray50)
     }
 }

--- a/MoonCrystal/MoonCrystal/OnoboardingView/onboardingStepView.swift
+++ b/MoonCrystal/MoonCrystal/OnoboardingView/onboardingStepView.swift
@@ -30,7 +30,6 @@ struct onboardingStepView: View {
                     Spacer()
                 }
             }
-//            .padding(.top, 100)
             
             LottieView(animation: .named(step.imageName))
                 .playing(loopMode: .loop)
@@ -49,7 +48,6 @@ struct onboardingStepView: View {
             }
             .padding(.top, 57)
         }
-//        .frame(maxHeight: .infinity)
         .background(.gray50)
     }
 }

--- a/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
+++ b/MoonCrystal/MoonCrystal/SelectCapacity/CapacitySettingView.swift
@@ -108,7 +108,6 @@ struct CapacitySettingView: View {
                 
                 Button {
                     path.append("PreCleanUpView")
-    
                 } label: {
                     RoundedRectangle(cornerRadius: 12)
                         .frame(height: 68)


### PR DESCRIPTION
## 📝 작업 내용

> 리젝 사유에 맞게 iPadOS를 타겟에서 삭제하고, 작은 사이즈 기기에서도 모든 레이아웃이 보이도록 일부 수정을 했습니다.

### 스크린샷 (선택)
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/a11d66db-3230-4fb1-88bf-19bd64d7c382">

## 💬 리뷰 요구사항(선택)

> 시뮬레이터(아이패드)를 사용해 작은 사이즈에서도 모든 레이아웃이 잘 표시되는지 확인 부탁드립니다.
>- 바텀 부분에 패딩을 추가했고, 몇 가지 수정을 진행했습니다.
>- 추가로, 향후 기기 사이즈에 따른 대응 방안을 디자인 팀과 함께 고민해보면 좋겠습니다.
---
> iOS 타겟 버전을 17.0으로 통일시켰습니다.