### PR TITLE
[#82] 온보딩 뷰 기기 별 사이즈 대응

### DIFF
--- a/MoonCrystal/MoonCrystal/OnoboardingView/OnboardingView.swift
+++ b/MoonCrystal/MoonCrystal/OnoboardingView/OnboardingView.swift
@@ -14,30 +14,15 @@ struct OnboardingView: View {
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
             TabView(selection: $currentStep) {
-                onboardingStepView(step: .first)
+                onboardingStepView(step: .first, stepButtonAction: moveToNextStep)
                     .tag(OnboardingStep.first)
                 
-                onboardingStepView(step: .second)
+                onboardingStepView(step: .second, stepButtonAction: moveToNextStep)
                     .tag(OnboardingStep.second)
                 
-                onboardingStepView(step: .third)
+                onboardingStepView(step: .third, stepButtonAction: moveToNextStep)
                     .tag(OnboardingStep.third)
-                
             }
-            
-            Button {
-                moveToNextStep()
-            } label: {
-                RoundedRectangle(cornerRadius: 12)
-                    .frame(height: 68)
-                    .foregroundStyle(.gray900)
-                    .overlay(
-                        Text(currentStep.buttonTitle)
-                            .font(.system(size: 16, weight: .regular))
-                            .foregroundStyle(.white))
-            }
-            .padding(.bottom, 86)
-            Spacer()
         }
         .padding(.horizontal)
         .background(.gray50)
@@ -78,4 +63,8 @@ struct OnboardingView: View {
             }
         }
     }
+}
+
+#Preview {
+    OnboardingView(isFirstLaunch: .constant(true))
 }

--- a/MoonCrystal/MoonCrystal/OnoboardingView/onboardingStepView.swift
+++ b/MoonCrystal/MoonCrystal/OnoboardingView/onboardingStepView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct onboardingStepView: View {
     let step: OnboardingStep
     
+    let stepButtonAction: () -> Void
+    
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -30,6 +32,7 @@ struct onboardingStepView: View {
                     Spacer()
                 }
             }
+            .padding(.top, 20)  //최소 패딩 걸어두기
             
             LottieView(animation: .named(step.imageName))
                 .playing(loopMode: .loop)
@@ -46,12 +49,27 @@ struct onboardingStepView: View {
                         .frame(width: 8)
                 }
             }
-            .padding(.top, 57)
+            .padding(.top, 50)
+            
+            Spacer()
+            Button {
+                stepButtonAction()
+            } label: {
+                RoundedRectangle(cornerRadius: 12)
+                    .frame(height: 68)
+                    .foregroundStyle(.gray900)
+                    .overlay(
+                        Text(step.buttonTitle)
+                            .font(.system(size: 16, weight: .regular))
+                            .foregroundStyle(.white))
+            }
         }
         .background(.gray50)
     }
 }
 
 #Preview {
-    onboardingStepView(step: .second)
+    onboardingStepView(step: .second, stepButtonAction: {
+        print("HI")
+    })
 }


### PR DESCRIPTION
## 📝 작업 내용

>- 온보딩 뷰를 작은 사이즈의 기기에서도 적절히 표시되도록 레이아웃을 수정했습니다.
>- 버튼의 위치 잡기가 어려워 기존의 onboardingView에서 로직을 onboardingStepView로 이동했습니다.
>- 레이아웃 조정을 통해 화면 잘림 및 UI 요소의 겹침 문제를 해결했습니다.