### PR TITLE
[#86] 포토카드가 들어가는 화면 간격 수정하기

### DIFF
--- a/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/DeletedTotalCapacityView.swift
+++ b/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/DeletedTotalCapacityView.swift
@@ -35,7 +35,6 @@ struct DeletedTotalCapacityView: View {
                 .frame(maxHeight: 56)
             
             MyFavoriteIdolCardView(deletedTotalCapacity: deletedTotalCapacity, userProfile: userProfile)
-                .padding(.bottom, .leastNonzeroMagnitude)
             Spacer()
         }
         .padding(.horizontal)

--- a/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/DeletedTotalCapacityView.swift
+++ b/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/DeletedTotalCapacityView.swift
@@ -15,20 +15,27 @@ struct DeletedTotalCapacityView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            Spacer()
+                .frame(maxHeight: 22)
+            
             HStack {
                 Text("최애를 위해 정리한 용량.zip")
                     .font(.system(size: 24, weight: .semibold))
                     .foregroundStyle(.gray900)
                 Spacer()
             }
-            .padding(.top, 22)
+            
+            Spacer()
+                .frame(maxHeight: 49)
             
             deletedTotalStatus
                 .frame(height: 60)
-                .padding(.top, 40)
+            
+            Spacer()
+                .frame(maxHeight: 56)
             
             MyFavoriteIdolCardView(deletedTotalCapacity: deletedTotalCapacity, userProfile: userProfile)
-                .padding(.top, 56)
+                .padding(.bottom, .leastNonzeroMagnitude)
             Spacer()
         }
         .padding(.horizontal)

--- a/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/EndCleanUpView.swift
+++ b/MoonCrystal/MoonCrystal/DeletedTotalCapacityView/EndCleanUpView.swift
@@ -15,6 +15,7 @@ struct EndCleanUpView: View {
     
     var body: some View {
         VStack(spacing: 0) {
+            Spacer()
             HStack {
                 Text("정리가 종료됐어요!")
                     .font(.system(size: 24, weight: .semibold))
@@ -24,7 +25,6 @@ struct EndCleanUpView: View {
                     .offset(y: -6)
                 Spacer()
             }
-            .padding(.top, 116)
             
             HStack {
                 Text("포토카드에 \(userProfile?.nickname ?? "당신")의 마음을 담았어요")
@@ -34,8 +34,13 @@ struct EndCleanUpView: View {
             }
             .padding(.top, 8)
             
+            Spacer()
+                .frame(maxHeight: 57)
+            
             MyFavoriteIdolCardView(deletedTotalCapacity: deletedTotalCapacity, currentDeletedCapacity: cleanUpCapacity , isEndView: true, userProfile: userProfile)
-                .padding(.top, 57)
+            
+            Spacer()
+                .frame(maxHeight: 65)
             
             Button {
                 path.removeAll()
@@ -47,14 +52,15 @@ struct EndCleanUpView: View {
                         Text("확인")
                             .foregroundStyle(.white)
                     )
-                    .padding(.top, 65)
-                    .padding(.bottom, 80)
             }
             Spacer()
         }
         .padding(.horizontal)
-        .background(Color.gray50)
-        .edgesIgnoringSafeArea(.all)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background{
+            Color.gray50
+                .ignoresSafeArea(.all)
+        }
         .navigationBarBackButtonHidden()
         .onAppear {
             // 종료 클릭 시 다이나믹 종료


### PR DESCRIPTION
## 📝 작업 내용
- DeletedTotalCapacityView와 EndCleanUpView에서 전체 화면 사이즈가 작아질 경우 버튼이 잘리거나 간격이 어색한 문제를 해결하기 위해 페딩을 스페이서로 변경함
- EndCleanUpView에서 아이폰 SE로 화면을 볼 때 safeArea로 텍스트가 넘치는 걸 막기 위해 ignoresafeArea를 이동함

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-12 at 18 15 32](https://github.com/user-attachments/assets/f42e7df8-13f8-4b26-bab7-dd4656856881) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-12 at 18 15 53](https://github.com/user-attachments/assets/b1da062d-deeb-4e13-8bf1-9263798c568f) |
|------|---|

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
