### PR TITLE
[#103] 프로필 화면에 키보드 내려가기 기능 추가

### DIFF
--- a/MoonCrystal/MoonCrystal/Sources/Views/UserProfileView/UserProfileCreationView/UserProfileTextInputPageView.swift
+++ b/MoonCrystal/MoonCrystal/Sources/Views/UserProfileView/UserProfileCreationView/UserProfileTextInputPageView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct UserProfileTextInputPageView: View {
+    @FocusState var isTextFieldFocused: Bool
     @Binding var currentPage: Int
     @Binding var userProfileData: UserProfileInputModel
     
@@ -37,6 +38,7 @@ struct UserProfileTextInputPageView: View {
                 .frame(maxHeight: 42)
             
             TextField("", text: bindingForCurrentPage())
+                .focused($isTextFieldFocused)
                 .font(.system(size: 16, weight: .regular))
                 .frame(height: 48)
                 .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
@@ -80,6 +82,9 @@ struct UserProfileTextInputPageView: View {
         }
         .background(.gray50)
         .ignoresSafeArea(.all, edges: .bottom)
+        .onTapGesture {
+            isTextFieldFocused = false
+        }
     }
     
     private func bindingForCurrentPage() -> Binding<String> {

--- a/MoonCrystal/MoonCrystal/Sources/Views/UserProfileView/UserProfileDetailView.swift
+++ b/MoonCrystal/MoonCrystal/Sources/Views/UserProfileView/UserProfileDetailView.swift
@@ -13,7 +13,8 @@ struct UserProfileDetailView: View {
     
     @Environment(\.presentationMode) var presentationMode
     
-    @State var keyboardHeight : CGFloat = 0
+    @FocusState var focusedField: String?
+    @State var keyboardHeight: CGFloat = 0
     @State private var isEditing = false
     @State private var userProfileInputData = UserProfileInputModel()
     
@@ -55,6 +56,9 @@ struct UserProfileDetailView: View {
                 editSaveButton
             }
         }
+        .onTapGesture {
+            focusedField = nil
+        }
     }
     
     // 프로필 이미지 섹션
@@ -82,6 +86,7 @@ struct UserProfileDetailView: View {
                 Spacer()
             }
             TextField("", text: text)
+                .focused($focusedField, equals: title)
                 .frame(height: 48)
                 .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                 .background(.white)
@@ -103,6 +108,9 @@ struct UserProfileDetailView: View {
                         // 최대 글자 수를 초과하면 초과 부분을 제거
                         text.wrappedValue = String(text.wrappedValue.prefix(maxTextCount))
                     }
+                }
+                .onTapGesture {
+                    focusedField = title
                 }
         }
     }


### PR DESCRIPTION
## 📝 작업 내용
- UserProfileTextInputPageVIew와 UserProfileDetailView에 각각 빈 공간을 클릭시 키보드가 내려가도록 설정함
- 특히 UserProfileDetailView에서는 텍스트 필드 간 서로 선택 시 키보드가 내려가지 않고 포커스 상태만 이동하도록 설정함

### 스크린샷 (선택)
|프로필 화면 입력시 키보드 내리기| 프로필 화면 수정 화면 |
|--|--|
|<img src="https://github.com/user-attachments/assets/006f2777-7a3c-4982-a427-4cd8b600a328" width="393" height="852"> | <img src="https://github.com/user-attachments/assets/989340bb-c11c-4952-ab80-38ec5600911e" width="393" height="852"> |

## 💬 리뷰 요구사항(선택)

> gif 만들 때 첫화면에서 실수로 중간에 제가 노트북 키보드 타이핑 눌러서 내려간 부분 있습니다. 에러 아니고 휴먼에러에요ㅠㅠ
> 첫 프로필 설정화면에서 설정할 때 프로그레스 바 위쪽 영역을 클릭시에는 키보드가 내려가지 않도록 되어있습니다.
> 조금 더 상위 화면과 하위 화면을 동시에 건드려야 하는 번거로움도 있었지만 툴바나 프로그레스 바가 있는 영역을 눌러서 키보드가 내려가는 건 어색하다고 판단했습니다.
